### PR TITLE
support epoch duration and time

### DIFF
--- a/src/__tests__/Parser.spec.ts
+++ b/src/__tests__/Parser.spec.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest'
+import DefaultParser from '@/service/DefaultParser'
+import EpochParser from '@/service/EpochParser'
+import ParserFactory from '@/service/ParserFactory'
+import type StartupDto from '@/model/dto/StartupDto'
+
+describe('Parser', () => {
+  describe('DefaultParser (ISO8601)', () => {
+    it('should parse ISO8601 timestamps correctly', () => {
+      const parser = new DefaultParser()
+      const data: StartupDto = {
+        springBootVersion: '3.0.0',
+        timeline: {
+          startTime: '2023-10-06T19:36:56.928306Z',
+          events: [
+            {
+              endTime: '2023-10-06T19:36:57.011537100Z',
+              duration: 'PT0.0668144S',
+              startTime: '2023-10-06T19:36:56.944722700Z',
+              startupStep: {
+                name: 'spring.boot.application.starting',
+                id: 0,
+                parentId: null,
+                tags: [
+                  {
+                    key: 'mainApplicationClass',
+                    value: 'com.github.alexeylapin.startupdemo.SpringStartupDemo',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+
+      const result = parser.parse(JSON.stringify(data))
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0]!.name).toBe('spring.boot.application.starting')
+      expect(result.springBootVersion).toBe('3.0.0')
+      expect(result.totalDuration).toBeGreaterThan(0)
+    })
+  })
+
+  describe('EpochParser', () => {
+    it('should parse epoch timestamps correctly', () => {
+      const parser = new EpochParser()
+      const data: StartupDto = {
+        springBootVersion: '3.1.4',
+        timeline: {
+          startTime: '1696618616.928306',
+          events: [
+            {
+              endTime: '1696618617.011537',
+              duration: '0.066814',
+              startTime: '1696618616.944722',
+              startupStep: {
+                name: 'spring.boot.application.starting',
+                id: 0,
+                parentId: null,
+                tags: [
+                  {
+                    key: 'mainApplicationClass',
+                    value: 'com.github.alexeylapin.startupdemo.SpringStartupDemo',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+
+      const result = parser.parse(JSON.stringify(data))
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0]!.name).toBe('spring.boot.application.starting')
+      expect(result.events[0]!.duration).toBeCloseTo(66.814, 1)
+      expect(result.springBootVersion).toBe('3.1.4')
+      expect(result.totalDuration).toBeCloseTo(66.814, 1)
+    })
+
+    it('should handle Date objects correctly', () => {
+      const parser = new EpochParser()
+      const data: StartupDto = {
+        springBootVersion: '3.1.4',
+        timeline: {
+          startTime: '1696618616.928306',
+          events: [
+            {
+              endTime: '1696618617.011537',
+              duration: '0.1',
+              startTime: '1696618616.944722',
+              startupStep: {
+                name: 'test.step',
+                id: 0,
+                parentId: null,
+                tags: [],
+              },
+            },
+          ],
+        },
+      }
+
+      const result = parser.parse(JSON.stringify(data))
+
+      expect(result.events[0]!.startTime).toBeInstanceOf(Date)
+      expect(result.events[0]!.endTime).toBeInstanceOf(Date)
+      expect(result.events[0]!.startTime.getTime()).toBe(1696618616944)
+      expect(result.events[0]!.endTime.getTime()).toBe(1696618617011)
+    })
+
+    it('should handle numeric epoch timestamps', () => {
+      const parser = new EpochParser()
+      const data = {
+        springBootVersion: '3.1.4',
+        timeline: {
+          startTime: 1768490605.402159,
+          events: [
+            {
+              endTime: 1768490605.59354721,
+              duration: 0.191387578,
+              startTime: 1768490605.402159632,
+              startupStep: {
+                name: 'spring.beans.smart-initialize',
+                id: 1702,
+                tags: [{ key: 'beanName', value: 'meterRegistryPostProcessor' }],
+                parentId: 4,
+              },
+            },
+            {
+              endTime: 1768490605.593635694,
+              duration: 0.000010641,
+              startTime: 1768490605.593625053,
+              startupStep: {
+                name: 'spring.beans.smart-initialize',
+                id: 1703,
+                tags: [{ key: 'beanName', value: 'entityManagerFactory' }],
+                parentId: 4,
+              },
+            },
+          ],
+        },
+      }
+
+      const result = parser.parse(JSON.stringify(data))
+
+      expect(result.events).toHaveLength(2)
+      expect(result.events[0]!.name).toBe('spring.beans.smart-initialize')
+      expect(result.events[0]!.duration).toBeCloseTo(191.387578, 1)
+      expect(result.events[1]!.duration).toBeCloseTo(0.010641, 3)
+    })
+  })
+
+  describe('ParserFactory', () => {
+    it('should auto-detect ISO8601 format and return DefaultParser', () => {
+      const data = {
+        timeline: {
+          events: [
+            {
+              startTime: '2023-10-06T19:36:56.928306Z',
+              endTime: '2023-10-06T19:36:57.011537100Z',
+              duration: 'PT0.0668144S',
+              startupStep: { id: 0, name: 'test', tags: [] },
+            },
+          ],
+        },
+      }
+
+      const parser = ParserFactory.createParser(JSON.stringify(data))
+      expect(parser).toBeInstanceOf(DefaultParser)
+    })
+
+    it('should auto-detect epoch format and return EpochParser', () => {
+      const data = {
+        timeline: {
+          events: [
+            {
+              startTime: 1696618616.928306,
+              endTime: 1696618617.011537,
+              duration: 0.066814,
+              startupStep: { id: 0, name: 'test', tags: [] },
+            },
+          ],
+        },
+      }
+
+      const parser = ParserFactory.createParser(JSON.stringify(data))
+      expect(parser).toBeInstanceOf(EpochParser)
+    })
+
+    it('should default to DefaultParser for invalid JSON', () => {
+      const parser = ParserFactory.createParser('invalid json')
+      expect(parser).toBeInstanceOf(DefaultParser)
+    })
+
+    it('should default to DefaultParser for empty events', () => {
+      const data = {
+        timeline: {
+          events: [],
+        },
+      }
+
+      const parser = ParserFactory.createParser(JSON.stringify(data))
+      expect(parser).toBeInstanceOf(DefaultParser)
+    })
+  })
+})

--- a/src/assets/sample-epoch.json
+++ b/src/assets/sample-epoch.json
@@ -1,0 +1,43 @@
+{
+  "springBootVersion": "3.1.4",
+  "timeline": {
+    "startTime": 1696618616.928306,
+    "events": [
+      {
+        "endTime": 1696618617.011537,
+        "duration": 0.066814,
+        "startTime": 1696618616.944722,
+        "startupStep": {
+          "name": "spring.boot.application.starting",
+          "id": 0,
+          "tags": [
+            {
+              "key": "mainApplicationClass",
+              "value": "com.github.alexeylapin.startupdemo.SpringStartupDemo"
+            }
+          ]
+        }
+      },
+      {
+        "endTime": 1696618617.370104,
+        "duration": 0.225399,
+        "startTime": 1696618617.144705,
+        "startupStep": {
+          "name": "spring.boot.application.environment-prepared",
+          "id": 1,
+          "tags": []
+        }
+      },
+      {
+        "endTime": 1696618617.446362,
+        "duration": 0.000389,
+        "startTime": 1696618617.445972,
+        "startupStep": {
+          "name": "spring.boot.application.context-prepared",
+          "id": 2,
+          "tags": []
+        }
+      }
+    ]
+  }
+}

--- a/src/service/EpochParser.ts
+++ b/src/service/EpochParser.ts
@@ -1,0 +1,81 @@
+import type DataNode from '@/model/DataNode'
+import type Event from '@/model/Event'
+import type EventDto from '@/model/dto/EventDto'
+import type ParseResult from '@/model/ParseResult'
+import type Parser from '@/service/Parser'
+import type StartupDto from '@/model/dto/StartupDto'
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
+
+// Enable duration plugin for dayjs
+dayjs.extend(duration)
+
+export default class EpochParser implements Parser {
+  parse(payloadString: string): ParseResult {
+    const startupData = JSON.parse(payloadString) as StartupDto
+
+    const map = new Map<string, DataNode>()
+
+    let totalDuration = 0
+
+    const treeNodes = startupData.timeline.events
+      .map((item) => this.convertNode(item))
+      .map((item) => {
+        map.set(item.key, item)
+        if (item.data.parentId === null) {
+          totalDuration += item.data.summary
+        }
+        return item
+      })
+
+    const events: Event[] = []
+    treeNodes.forEach((item) => {
+      events.push(item.data)
+      item.data.percentage = Number(((item.data.duration / totalDuration) * 100).toFixed(1))
+      const parentId = item.data.parentId
+      if (parentId !== null) {
+        const parent = map.get(String(parentId))
+        if (parent !== undefined) {
+          parent.children.push(item)
+          parent.data.duration -= item.data.summary
+          parent.leaf = false
+        }
+      }
+    })
+    const nodes = treeNodes.filter((item) => item.data.parentId === null)
+
+    return {
+      totalDuration: totalDuration,
+      events: events,
+      nodes: nodes,
+      springBootVersion: startupData.springBootVersion ?? null,
+    }
+  }
+
+  private convertNode(item: EventDto): DataNode {
+    const startTimeSeconds = Number(item.startTime)
+    const endTimeSeconds = Number(item.endTime)
+    const durationSeconds = Number(item.duration)
+
+    const startTimeMs = startTimeSeconds * 1000
+    const endTimeMs = endTimeSeconds * 1000
+    const durationMs = durationSeconds * 1000
+
+    return {
+      key: String(item.startupStep.id),
+      data: {
+        id: item.startupStep.id,
+        parentId: item.startupStep.parentId ?? null,
+        name: item.startupStep.name,
+        summary: durationMs,
+        duration: durationMs,
+        percentage: 0,
+        startTime: new Date(startTimeMs),
+        endTime: new Date(endTimeMs),
+        tags: item.startupStep.tags,
+      },
+      children: [],
+      leaf: true,
+    }
+  }
+}

--- a/src/service/ParserFactory.ts
+++ b/src/service/ParserFactory.ts
@@ -1,0 +1,35 @@
+import DefaultParser from '@/service/DefaultParser'
+import EpochParser from '@/service/EpochParser'
+import type Parser from '@/service/Parser'
+
+export default class ParserFactory {
+  /**
+   * Creates the appropriate parser based on the payload format.
+   * Auto-detects whether the timestamps are in ISO8601 or epoch format.
+   */
+  static createParser(payloadString: string): Parser {
+    try {
+      const data = JSON.parse(payloadString)
+
+      if (data?.timeline?.events && data.timeline.events.length > 0) {
+        const firstEvent = data.timeline.events[0]
+
+        if (firstEvent.startTime) {
+          const startTime = firstEvent.startTime
+
+          if (typeof startTime === 'string' && (startTime.includes('T') || startTime.includes('Z'))) {
+            return new DefaultParser()
+          }
+
+          if (typeof startTime === 'number' || !isNaN(Number(startTime))) {
+            return new EpochParser()
+          }
+        }
+      }
+
+      return new DefaultParser()
+    } catch {
+      return new DefaultParser()
+    }
+  }
+}


### PR DESCRIPTION
On my app the /startup endpoint return duration and dates in epoch decimal timestamp so I had broken times and duration values when using your app. 

I have added a second parser that support epoch. the parser is instantiated based on the the format found of the given input file.